### PR TITLE
Filename only option (-f) working with JSON output

### DIFF
--- a/main.c
+++ b/main.c
@@ -98,6 +98,13 @@ static bool callback(FileMonitor *fm, FileMonitorEvent *ev) {
 		}
 	}
 	if (fm->json || fm->jsonStream) {
+		if (fm->fileonly && ev->file) {
+			const char *p = ev->file;
+			for (p = p + strlen (p); p > ev->file; p--) {
+				if (*p == '/')
+					ev->file = p + 1;
+			}
+		}
 		if (fm->jsonStream) {
 			firstnode = true;
 		}


### PR DESCRIPTION
I noticed that the -f option did not do anything when outputting JSON.
Therefore I copied the logic to remove the path from the fm->file property from the normal output to the json output.

Maybe another option would be, to factor out a remove_path(char* filename){} function.