### PR TITLE
Fix JSON comma delimiters

### DIFF
--- a/main.c
+++ b/main.c
@@ -102,12 +102,12 @@ static bool callback(FileMonitor *fm, FileMonitorEvent *ev) {
 			firstnode = true;
 		}
 		char *filename = fmu_jsonfilter (ev->file);
-		printf ("%s{\"filename\":\"%s\"", (fm->jsonStream || firstnode)? "":",", filename);
+		printf ("%s{\"filename\":\"%s\",", (fm->jsonStream || firstnode)? "":",", filename);
 		if (ev->pid) {
-			printf (",\"pid\":%d", ev->pid);
+			printf ("\"pid\":%d,", ev->pid);
 		}
 		if (ev->uid && ev->gid) {
-			printf (",\"uid\":%d,\"gid\":%d,", ev->uid, ev->gid);
+			printf ("\"uid\":%d,\"gid\":%d,", ev->uid, ev->gid);
 		}
 		firstnode = false;
 		free (filename);


### PR DESCRIPTION
Currently, if there are no [p,u,g]id values set, there will be a comma missing from the JSON output.
My fix will make sure that any added JSON attribute has a comma at the end, before the JSON object is completed by the type attribute.